### PR TITLE
Extracts PEP 593 annotations from mapping keys and not from type

### DIFF
--- a/apischema/__init__.py
+++ b/apischema/__init__.py
@@ -26,7 +26,6 @@ from . import (  # noqa: F401
     metadata,
     settings,
     skip,
-    tagged_unions,
     validation,
 )
 from .aliases import alias

--- a/apischema/__init__.py
+++ b/apischema/__init__.py
@@ -4,14 +4,9 @@ __all__ = [
     "Unsupported",
     "ValidationError",
     "alias",
-    "conversions",
-    "dataclasses",
     "deserialization",
     "deserialize",
     "deserializer",
-    "fields",
-    "json_schema",
-    "metadata",
     "properties",
     "reset_cache",
     "schema",
@@ -19,14 +14,11 @@ __all__ = [
     "serialize",
     "serialized",
     "serializer",
-    "settings",
-    "skip",
-    "validation",
     "validator",
 ]
 
 
-from . import (
+from . import (  # noqa: F401
     conversions,
     dataclasses,
     fields,
@@ -34,6 +26,7 @@ from . import (
     metadata,
     settings,
     skip,
+    tagged_unions,
     validation,
 )
 from .aliases import alias

--- a/apischema/conversions/utils.py
+++ b/apischema/conversions/utils.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Generic, Optional, Tuple, Type, TypeVar,
 
 from apischema.types import AnyType, COLLECTION_TYPES, MAPPING_TYPES, PRIMITIVE_TYPES
 from apischema.typing import get_args, get_origin, get_type_hints
-from apischema.utils import get_parameters, is_type_var, substitute_type_vars, type_name
+from apischema.utils import get_parameters, is_type_var, substitute_type_vars
 
 try:
     from apischema.typing import Annotated
@@ -88,10 +88,7 @@ def get_conversion_type(base: AnyType, other: AnyType) -> Tuple[AnyType, AnyType
         return base, other
     args = get_args(base)
     if not all(map(is_type_var, args)):
-        raise TypeError(
-            f"Generic conversion doesn't support specialization,"
-            f" aka {type_name(base)}[{','.join(map(type_name, args))}]"
-        )
+        raise TypeError("Generic conversion doesn't support specialization")
     return origin, substitute_type_vars(other, dict(zip(args, get_parameters(origin))))
 
 

--- a/apischema/deserialization/__init__.py
+++ b/apischema/deserialization/__init__.py
@@ -298,11 +298,13 @@ class DeserializationMethodVisitor(
     ) -> DeserializationMethodFactory:
         factory = self.visit(tp)
         for annotation in reversed(annotations):
-            if isinstance(annotation, Schema):
-                factory = factory.merge(constraints=annotation.constraints)
-            if isinstance(annotation, ValidatorsMetadata):
-                factory = factory.merge(validators=annotation.validators)
-
+            if isinstance(annotation, Mapping):
+                if SCHEMA_METADATA in annotation:
+                    schema: Schema = annotation[SCHEMA_METADATA]
+                    factory = factory.merge(constraints=schema.constraints)
+                if VALIDATORS_METADATA in annotation:
+                    validators: ValidatorsMetadata = annotation[VALIDATORS_METADATA]
+                    factory = factory.merge(validators=validators.validators)
         return factory
 
     def any(self) -> DeserializationMethodFactory:

--- a/apischema/graphql/schema.py
+++ b/apischema/graphql/schema.py
@@ -72,7 +72,6 @@ from apischema.utils import (
     get_origin2,
     is_union_of,
     to_camel_case,
-    type_name,
 )
 
 JsonScalar = graphql.GraphQLScalarType(
@@ -95,10 +94,6 @@ class MissingRef(Exception):
 
 class Nullable(Exception):
     pass
-
-
-def ref_or_name(tp: AnyType) -> str:
-    return get_ref(tp) or type_name(tp)
 
 
 T = TypeVar("T")
@@ -188,8 +183,8 @@ class SchemaBuilder(ConversionsVisitor[Conv, Thunk[graphql.GraphQLType]]):
                 if not isinstance(ref, str):
                     raise ValueError("Annotated schema_ref can only be str")
                 self._ref = self._ref or ref
-            if isinstance(annotation, Schema):
-                self._schema = merge_schema(annotation, self._schema)
+            if isinstance(annotation, Mapping) and SCHEMA_METADATA in annotation:
+                self._schema = merge_schema(annotation[SCHEMA_METADATA], self._schema)
         return self.visit_with_schema(tp, self._ref, self._schema)
 
     def any(self) -> Thunk[graphql.GraphQLType]:

--- a/apischema/json_schema/generation/schema.py
+++ b/apischema/json_schema/generation/schema.py
@@ -141,8 +141,8 @@ class SchemaBuilder(ConversionsVisitor[Conv, JsonSchema]):
                 ref = annotation.ref
                 if not isinstance(ref, str):
                     raise ValueError("Annotated schema_ref can only be str")
-            if isinstance(annotation, Schema):
-                self._merge_schema(annotation)
+            if isinstance(annotation, Mapping) and SCHEMA_METADATA in annotation:
+                self._merge_schema(annotation[SCHEMA_METADATA])
         return self.visit_with_schema(tp, self._schema)
 
     @with_schema

--- a/apischema/json_schema/schema.py
+++ b/apischema/json_schema/schema.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from apischema.types import AnyType, MetadataMixin, Number
-from apischema.utils import Undefined, merge_opts, replace_builtins
+from apischema.utils import Undefined, contains, merge_opts, replace_builtins
 from .annotations import Annotations, Deprecated, merge_annotations
 from .constraints import (
     ArrayConstraints,
@@ -44,7 +44,7 @@ class Schema(MetadataMixin):
     def __call__(self, tp: T) -> T:
         if get_origin(tp) is Annotated:
             raise TypeError("Cannot register schema on Annotated type")
-        _schema[replace_builtins(tp)] = self
+        _schemas[replace_builtins(tp)] = self
         return tp
 
     def __set_name__(self, owner, name):
@@ -174,12 +174,12 @@ def _default_schema(tp: AnyType) -> Optional[Schema]:
     return None
 
 
-_schema: Dict[Any, Schema] = {}
+_schemas: Dict[Any, Schema] = {}
 
 
 def get_schema(tp: AnyType) -> Optional[Schema]:
     tp = replace_builtins(tp)
-    return _schema[tp] if tp in _schema else _default_schema(tp)
+    return _schemas[tp] if contains(_schemas, tp) else _default_schema(tp)
 
 
 @merge_opts

--- a/apischema/metadata/implem.py
+++ b/apischema/metadata/implem.py
@@ -25,7 +25,7 @@ def simple_metadata(key: str) -> Metadata:
     return MappingWithUnion({key: ...})
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConversionMetadata(MetadataMixin):
     key = CONVERSIONS_METADATA
     deserialization: Optional["ConvOrFunc"] = None

--- a/apischema/utils.py
+++ b/apischema/utils.py
@@ -6,6 +6,7 @@ from types import FunctionType
 from typing import (
     Any,
     Callable,
+    Collection,
     Dict,
     Generic,
     Hashable,
@@ -69,20 +70,18 @@ def to_hashable(data: Union[None, int, float, str, bool, list, dict]) -> Hashabl
     return data  # type: ignore
 
 
+def contains(collection: Collection[T], obj: T) -> bool:
+    try:
+        return obj in collection
+    except TypeError:
+        return False
+
+
 SNAKE_CASE_REGEX = re.compile(r"_([a-z\d])")
 
 
 def to_camel_case(s: str):
     return SNAKE_CASE_REGEX.sub(lambda m: m.group(1).upper(), s)
-
-
-def type_name(tp: AnyType) -> str:
-    if hasattr(tp, "__name__"):
-        return tp.__name__
-    elif isinstance(tp, _GenericAlias):
-        return tp._name
-    else:
-        raise NotImplementedError
 
 
 MakeDataclassField = Union[Tuple[str, AnyType], Tuple[str, AnyType, Any]]
@@ -162,7 +161,9 @@ def get_args2(tp: AnyType) -> Tuple[AnyType, ...]:
 
 
 def get_origin_or_type(tp: AnyType) -> Type:
-    origin = get_origin2(tp)
+    origin = get_origin(tp)
+    if origin is Annotated:
+        return get_origin_or_type(get_args(tp)[0])
     return origin if origin is not None else tp
 
 


### PR DESCRIPTION
It enables to use schema(...) | validators(...) in annotations instead of 2 annotations