### PR TITLE
Use get_args instead of get_origin to check if a type is generic

### DIFF
--- a/apischema/visitor.py
+++ b/apischema/visitor.py
@@ -239,7 +239,7 @@ class Visitor(Generic[Return]):
         return self.unsupported(tp)
 
     def visit(self, tp: AnyType) -> Return:
-        if get_origin(tp) is not None:
+        if get_args(tp):
             return self._visit_generic(tp)
         if is_type_var(tp):
             if tp.__constraints__:


### PR DESCRIPTION
In Python 3.9, get_origin(List) == list but get_args(List) == ()