### PR TITLE
Fix handling of Undefined outside Union

### DIFF
--- a/apischema/deserialization/__init__.py
+++ b/apischema/deserialization/__init__.py
@@ -661,7 +661,6 @@ class DeserializationMethodVisitor(
         factories = [
             self.visit(alt) for alt in alternatives if alt is not UndefinedType
         ]
-        factories = list(map(self.visit, alternatives))
         optional = NoneType in alternatives
 
         @DeserializationMethodFactory

--- a/apischema/types.py
+++ b/apischema/types.py
@@ -17,6 +17,7 @@ from typing import (
     MutableSet,
     Sequence,
     Set,
+    TYPE_CHECKING,
     Tuple,
     Type,
     Union,
@@ -117,17 +118,25 @@ class MetadataImplem(dict, Metadata):  # type: ignore
 
 
 # Singleton type, see https://www.python.org/dev/peps/pep-0484/#id30
-class UndefinedType(Enum):
-    def __repr__(self):
-        return "Undefined"
+if TYPE_CHECKING:
 
-    def __str__(self):
-        return "Undefined"
+    class UndefinedType(Enum):
+        Undefined = auto()
 
-    def __bool__(self):
-        return False
+    Undefined = UndefinedType.Undefined
+else:
 
-    Undefined = auto()
+    class UndefinedType:
+        def __new__(cls):
+            return Undefined
 
+        def __repr__(self):
+            return "Undefined"
 
-Undefined = UndefinedType.Undefined
+        def __str__(self):
+            return "Undefined"
+
+        def __bool__(self):
+            return False
+
+    Undefined = object.__new__(UndefinedType)


### PR DESCRIPTION
UndefinedType was handled as an Enum because it was declared as an Enum. `if TYPE_CHECKING` pattern solves this issue