### PR TITLE
Move is_async and unwrap_awaitable to utils module, fix method_wrapper not detecting async methods

### DIFF
--- a/apischema/graphql/relay/mutations.py
+++ b/apischema/graphql/relay/mutations.py
@@ -17,14 +17,13 @@ from typing import (
 from graphql.pyutils import camel_to_snake
 
 from apischema.aliases import alias
-from apischema.graphql.resolvers import is_async
 from apischema.graphql.schema import Mutation as Mutation_
 from apischema.json_schema.schemas import Schema
 from apischema.serialization.serialized_methods import ErrorHandler
 from apischema.type_names import type_name
 from apischema.types import AnyType, Undefined
 from apischema.typing import get_type_hints
-from apischema.utils import is_union_of
+from apischema.utils import is_union_of, is_async
 
 ClientMutationId = NewType("ClientMutationId", str)
 type_name(None)(ClientMutationId)

--- a/apischema/graphql/resolvers.py
+++ b/apischema/graphql/resolvers.py
@@ -41,9 +41,11 @@ from apischema.typing import get_origin, get_type_hints
 from apischema.utils import (
     get_args2,
     get_origin_or_type2,
+    is_async,
     is_union_of,
     keep_annotations,
     method_registerer,
+    unwrap_awaitable
 )
 from apischema.validation.errors import ValidationError
 
@@ -60,28 +62,6 @@ def partial_serialize(
     obj: Any, *, conversions: HashableConversions = None, aliaser: Aliaser
 ) -> Any:
     return partial_serialization_method(obj.__class__, conversions, aliaser)(obj, False)
-
-
-awaitable_origin = get_origin(Awaitable[Any])
-
-
-def is_async(func: Callable, types: Mapping[str, AnyType] = None) -> bool:
-    if types is None:
-        try:
-            types = get_type_hints(func)
-        except Exception:
-            types = {}
-    return (
-        iscoroutinefunction(func)
-        or get_origin_or_type2(types.get("return")) == awaitable_origin
-    )
-
-
-def unwrap_awaitable(tp: AnyType) -> AnyType:
-    if get_origin_or_type2(tp) == awaitable_origin:
-        return keep_annotations(get_args2(tp)[0] if get_args2(tp) else Any, tp)
-    else:
-        return tp
 
 
 @dataclass(frozen=True)

--- a/tests/test_method_wrapper.py
+++ b/tests/test_method_wrapper.py
@@ -1,0 +1,20 @@
+from apischema.utils import method_wrapper
+from apischema.utils import is_async
+# from apischema.graphql.resolvers import is_async
+
+class TestClass:
+    def foo():
+        ...
+    
+    async def bar():
+        ...
+
+
+def test_sync():    
+    wrapper = method_wrapper(TestClass.foo)
+    assert not is_async(wrapper)
+
+
+def test_async():
+    wrapper = method_wrapper(TestClass.bar)
+    assert is_async(wrapper)


### PR DESCRIPTION
Move is_async and unwrap_awaitable to utils module, fix method_wrapper obscuring async methods. Add tests to ensure that `is_async` recognises async method wrappers.

Example code that this fixes, the `bar` resolver previously generated "never awaited" errors:
```
import asyncio
from dataclasses import dataclass
from typing import Optional

from apischema.graphql import graphql_schema, resolver
from graphql import graphql


@dataclass
class Foo:
    @resolver
    async def bar(self) -> int:
        return 5

    @resolver
    def baz(self) -> str:
        return "hi"


async def foo() -> Optional[Foo]:
    return Foo()


schema = graphql_schema(query=[foo])
query = """
{
  foo {
    bar
  }
}
"""

data = asyncio.run(graphql(schema, query)).data
print(f"Data: {data}")
```
