### PR TITLE
Fix async resolver method not being handled as async

### DIFF
--- a/apischema/graphql/relay/mutations.py
+++ b/apischema/graphql/relay/mutations.py
@@ -17,14 +17,13 @@ from typing import (
 from graphql.pyutils import camel_to_snake
 
 from apischema.aliases import alias
-from apischema.graphql.resolvers import is_async
 from apischema.graphql.schema import Mutation as Mutation_
 from apischema.json_schema.schemas import Schema
 from apischema.serialization.serialized_methods import ErrorHandler
 from apischema.type_names import type_name
 from apischema.types import AnyType, Undefined
 from apischema.typing import get_type_hints
-from apischema.utils import is_union_of
+from apischema.utils import is_async, is_union_of
 
 ClientMutationId = NewType("ClientMutationId", str)
 type_name(None)(ClientMutationId)

--- a/apischema/graphql/resolvers.py
+++ b/apischema/graphql/resolvers.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import partial
-from inspect import Parameter, iscoroutinefunction, signature
+from inspect import Parameter, signature
 from typing import (
     Any,
     Awaitable,
@@ -37,10 +37,11 @@ from apischema.serialization.serialized_methods import (
     serialized as register_serialized,
 )
 from apischema.types import AnyType, NoneType, Undefined
-from apischema.typing import get_origin, get_type_hints
 from apischema.utils import (
+    awaitable_origin,
     get_args2,
     get_origin_or_type2,
+    is_async,
     is_union_of,
     keep_annotations,
     method_registerer,
@@ -60,21 +61,6 @@ def partial_serialize(
     obj: Any, *, conversions: HashableConversions = None, aliaser: Aliaser
 ) -> Any:
     return partial_serialization_method(obj.__class__, conversions, aliaser)(obj, False)
-
-
-awaitable_origin = get_origin(Awaitable[Any])
-
-
-def is_async(func: Callable, types: Mapping[str, AnyType] = None) -> bool:
-    if types is None:
-        try:
-            types = get_type_hints(func)
-        except Exception:
-            types = {}
-    return (
-        iscoroutinefunction(func)
-        or get_origin_or_type2(types.get("return")) == awaitable_origin
-    )
 
 
 def unwrap_awaitable(tp: AnyType) -> AnyType:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,11 @@
-from apischema.utils import to_camel_case, to_hashable
+from functools import lru_cache, wraps
+from itertools import repeat
+from typing import Awaitable
+
+from pytest import mark
+
+from apischema.typing import Annotated
+from apischema.utils import is_async, to_camel_case, to_hashable
 
 
 def test_to_hashable():
@@ -10,3 +17,54 @@ def test_to_hashable():
 
 def test_to_camel_case():
     assert to_camel_case("min_length") == "minLength"
+
+
+def sync_func():
+    ...
+
+
+async def async_func():
+    ...
+
+
+def func_not_returning_awaitable() -> int:
+    ...
+
+
+def func_returning_awaitable() -> Awaitable[int]:
+    ...
+
+
+sync_cases = [
+    sync_func,
+    wraps(sync_func)(lambda: sync_func()),
+    lru_cache()(sync_func),
+    func_not_returning_awaitable,
+]
+async_cases = [
+    async_func,
+    wraps(async_func)(lambda: async_func()),
+    lru_cache()(async_func),
+    func_returning_awaitable,
+]
+
+
+@mark.parametrize(
+    "func, expected", [*zip(sync_cases, repeat(False)), *zip(async_cases, repeat(True))]
+)
+def test_is_async(func, expected):
+    assert is_async(func) == expected
+
+
+@mark.parametrize(
+    "types, expected",
+    [
+        ({}, False),
+        ({"return": int}, False),
+        ({"return": Awaitable[int]}, True),
+        ({"return": Annotated[int, ...]}, False),
+        ({"return": Annotated[Awaitable[int], ...]}, True),
+    ],
+)
+def test_is_async_with_types(types, expected):
+    assert is_async(lambda: ..., types) == expected


### PR DESCRIPTION
Bug was reported by @callumforrester in #129 

Internal function `is_async` was not taking in account the potential wrapping of resolver functions (with `functools.wraps`, `functools.lru_cache`, etc.). As method handling is using `functools.wraps`, async resolver methods were thusnot detected as async method.
It has been fixed by taking in account wrapping chain in `is_async`.