### PR TITLE
Fix get_type_hints issue on resolver parameter with None default

### DIFF
--- a/apischema/graphql/resolvers.py
+++ b/apischema/graphql/resolvers.py
@@ -208,7 +208,7 @@ def resolver_resolve(
                 aliaser=aliaser,
                 default_fallback=param_field.default_fallback or None,
             )
-            opt_param = is_union_of(param_type, NoneType)
+            opt_param = is_union_of(param_type, NoneType) or param.default is None
             parameters.append(
                 (
                     aliaser(param_field.alias),

--- a/tests/integration/test_aliased_resolvers.py
+++ b/tests/integration/test_aliased_resolvers.py
@@ -1,17 +1,8 @@
-from dataclasses import dataclass
 from typing import Optional
-from unittest.mock import MagicMock
+
+from graphql import graphql_sync
 
 from apischema.graphql import graphql_schema
-from apischema.graphql.resolvers import (
-    resolver_resolve,
-    Resolver,
-    resolver_parameters,
-    resolver,
-    _resolvers,
-)
-from apischema.utils import to_camel_case
-from graphql import graphql_sync
 
 
 def foo(test: int) -> int:

--- a/tests/integration/test_resolver_default_parameter_not_serializable.py
+++ b/tests/integration/test_resolver_default_parameter_not_serializable.py
@@ -1,0 +1,42 @@
+from functools import wraps
+from typing import Union
+
+from graphql import graphql_sync
+from graphql.utilities import print_schema
+from pytest import mark
+
+from apischema import Undefined, UndefinedType
+from apischema.graphql import graphql_schema
+from apischema.skip import Skip
+from apischema.typing import Annotated
+
+
+class Foo:
+    pass
+
+
+@mark.parametrize(
+    "tp, default",
+    [(Union[UndefinedType, int], Undefined), (Union[int, Annotated[Foo, Skip]], Foo())],
+)
+def test_resolver_default_parameter_not_serializable(tp, default):
+    def resolver(arg=default) -> bool:
+        return arg is default
+
+    resolver.__annotations__["arg"] = tp
+    # wraps in order to trigger the bug of get_type_hints with None default value
+    resolver2 = wraps(resolver)(lambda arg=default: resolver(arg))
+    schema = graphql_schema(query=[resolver2])
+    assert (
+        print_schema(schema)
+        == """\
+type Query {
+  resolver(arg: Int): Boolean!
+}
+"""
+    )
+    assert (
+        graphql_sync(schema, "{resolver}").data
+        == graphql_sync(schema, "{resolver(arg: null)}").data
+        == {"resolver": True}
+    )


### PR DESCRIPTION
See https://github.com/python/typing/issues/775 about get_type_hints not giving Optional type to wrapped function with None-defaulted parameters