### PR TITLE
Dont crash with legacy graphql versions

### DIFF
--- a/apischema/__init__.py
+++ b/apischema/__init__.py
@@ -64,7 +64,7 @@ try:
     
     if not graphql.__version__.startswith("2"):
         __all__.append("graphql")
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 

--- a/apischema/__init__.py
+++ b/apischema/__init__.py
@@ -61,8 +61,9 @@ from .visitor import Unsupported
 
 try:
     from . import graphql  # noqa: F401
-
-    __all__.append("graphql")
+    
+    if not graphql.__version__.startswith("2"):
+        __all__.append("graphql")
 except ImportError:
     pass
 


### PR DESCRIPTION
We are still stuck on graphql-core 2 and cant use this library at all.

This change makes it completely ignore older versions of graphql.