### PR TITLE
Fix frozenset deserialization.

### DIFF
--- a/apischema/deserialization/methods.py
+++ b/apischema/deserialization/methods.py
@@ -309,6 +309,14 @@ class SetMethod(DeserializationMethod):
 
 
 @dataclass
+class FrozenSetMethod(DeserializationMethod):
+    method: DeserializationMethod
+
+    def deserialize(self, data: Any) -> Any:
+        return frozenset(self.method.deserialize(data))
+
+
+@dataclass
 class VariadicTupleMethod(DeserializationMethod):
     method: DeserializationMethod
 

--- a/tests/unit/test_deserialization_serialization.py
+++ b/tests/unit/test_deserialization_serialization.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import (
     AbstractSet,
     Any,
+    FrozenSet,
     List,
     Mapping,
     Optional,
@@ -30,6 +31,7 @@ uuid = str(uuid4())
 def bijection(cls, data, expected):
     obj = deserialize(cls, data)
     assert obj == expected
+    assert type(obj) is type(expected)
     assert serialize(cls, obj) == data
 
 
@@ -97,7 +99,8 @@ def test_primitive_error(data):
         (List, [0, SimpleDataclass(0)]),
         (Set, {0, SimpleDataclass(0)}),
         (Sequence, [0, SimpleDataclass(0)]),
-        (AbstractSet, frozenset([0, SimpleDataclass(0)])),
+        (AbstractSet, {0, SimpleDataclass(0)}),
+        (FrozenSet, frozenset([0, SimpleDataclass(0)])),
     ],
 )
 def test_collection(cls, expected):
@@ -188,7 +191,7 @@ def test_with_class_context():
     class BigInt(int):
         pass
 
-    bijection(BigInt, 100, 100)
+    bijection(BigInt, 100, BigInt(100))
 
 
 def test_properties():


### PR DESCRIPTION
Closes #341

Note that there is another unit test failure : the deserialization of BigInt is not a BigInt instance. For this test case, I've explicitly disabled the new type check since it is another issue.