### PR TITLE
Fix tuple deserialization.

### DIFF
--- a/apischema/deserialization/__init__.py
+++ b/apischema/deserialization/__init__.py
@@ -366,7 +366,7 @@ class DeserializationMethodVisitor(
                 method = ListCheckOnlyMethod(list_constraints, value_method)
             else:
                 method = ListMethod(list_constraints, value_method)
-            return VariadicTupleMethod(method) if isinstance(cls, tuple) else method
+            return VariadicTupleMethod(method) if issubclass(cls, tuple) else method
 
         return self._factory(factory, list)
 

--- a/tests/unit/test_deserialization_serialization.py
+++ b/tests/unit/test_deserialization_serialization.py
@@ -1,7 +1,17 @@
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import AbstractSet, Any, List, Mapping, Optional, Sequence, Set, Union
+from typing import (
+    AbstractSet,
+    Any,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 from uuid import UUID, uuid4
 
 import pytest
@@ -93,6 +103,18 @@ def test_primitive_error(data):
 def test_collection(cls, expected):
     data = [0, {"a": 0}]
     bijection(cls[Union[int, SimpleDataclass]], data, expected)
+
+
+def test_collection_tuple():
+    data = [0, {"a": 0}]
+    expected = (0, SimpleDataclass(0))
+    bijection(Tuple[2 * (Union[int, SimpleDataclass],)], data, expected)
+
+
+def test_collection_tuple_variadic():
+    data = [0, {"a": 0}]
+    expected = (0, SimpleDataclass(0))
+    bijection(Tuple[Union[int, SimpleDataclass], ...], data, expected)
 
 
 @pytest.mark.parametrize("data", [{}, ["", 0]])


### PR DESCRIPTION
Fixing a typo
```python
>>> deserialize(tuple[int, ...], [1, 2, 3])
[1, 2, 3]
```