### PR TITLE
Fix error message for the json schemas of non str-keyed mappings.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [-C]

--- a/apischema/json_schema/schema.py
+++ b/apischema/json_schema/schema.py
@@ -217,8 +217,8 @@ class SchemaBuilder(
         with context_setter(self):
             self._ignore_first_ref = True
             key = self.visit(key_type)
-        if key["type"] != JsonType.STRING:
-            raise ValueError("Mapping types must string-convertible key")
+        if "type" not in key or key["type"] != JsonType.STRING:
+            raise ValueError("Mapping types must have string-convertible keys")
         value = self.visit(value_type)
         if "pattern" in key:
             return json_schema(

--- a/tests/integration/test_deserialize_with_coercion.py
+++ b/tests/integration/test_deserialize_with_coercion.py
@@ -23,11 +23,7 @@ def test_coerce_json():
     key = "test"
     value = 2
     ret = deserialize(
-        MyClass,
-        {
-            "my_property": f'{{"{key}": {value}}}',
-        },
-        coerce=_coerce_json,
+        MyClass, {"my_property": f'{{"{key}": {value}}}'}, coerce=_coerce_json
     )
     assert isinstance(ret, MyClass)
     assert isinstance(ret.my_property, dict) and ret.my_property[key] == value

--- a/tests/integration/test_dict.py
+++ b/tests/integration/test_dict.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import Any, Dict, Mapping
 
 import pytest
 
@@ -6,6 +7,20 @@ from apischema import ValidationError, deserialize, serialize
 from apischema.json_schema import deserialization_schema, serialization_schema
 from apischema.metadata import flatten
 from apischema.typing import Annotated, TypedDict
+
+
+class MyDict(dict):
+    pass
+
+
+@pytest.mark.parametrize(
+    "tp", [dict, Dict[int, Any], pytest.param(MyDict, marks=pytest.mark.xfail), Mapping]
+)
+def test_dict(tp):
+    with pytest.raises(ValueError, match="string-convertible keys"):
+        deserialization_schema(tp)
+    with pytest.raises(ValueError, match="string-convertible keys"):
+        serialization_schema(tp)
 
 
 class TD1(TypedDict, total=False):


### PR DESCRIPTION
The following results in an unhandled error:
```python
from apischema.json_schema import serialization_schema
serialization_schema(dict)
```
```
File "/home/chanial/.cache/pypoetry/virtualenvs/sonouno-server-lh_mGmR0-py3.10/lib/python3.10/site-packages/apischema/json_schema/schema.py", line 221, in mapping
    if key["type"] != JsonType.STRING:
KeyError: 'type'
```
I have renamed the test file to be more inclusive. And xfailed one test, for which an Unsupported error is raised.