### PR TITLE
Fix NameError for subscriptions with custom Type

### DIFF
--- a/apischema/graphql/schema.py
+++ b/apischema/graphql/schema.py
@@ -859,11 +859,13 @@ def operation_resolver(operation: Union[Callable, Op], op_class: Type[Op]) -> Re
     op = operation.function
     if iscoroutinefunction(op):
 
+        @wraps(op)
         async def wrapper(_, *args, **kwargs):
             return await op(*args, **kwargs)
 
     else:
 
+        @wraps(op)
         def wrapper(_, *args, **kwargs):
             return op(*args, **kwargs)
 


### PR DESCRIPTION
When trying to initialize a GraphQL schema with a subscription returning a custom type, I experienced this error. It is easily fixed by properly wrapping the operation in the Resolver. I would appreciate a merge and maybe also a small update of the pip package.

Background: `get_type_hints` can't get the type hints for the wrapped method, because without knowing about the method it wraps the globalns can't be properly resolved and thus the return value is not found. This results in an error message similar to this one:
```
Traceback (most recent call last):
  File "/home/ludwig/BaseAsset.py", line 199, in <module>
    schema = graphql_schema(query=[],
  File "/home/ludwig/.pyenv/versions/3.10.1/lib/python3.10/site-packages/apischema/utils.py", line 400, in wrapper
    return wrapped(*args, **kwargs)
  File "/home/ludwig/.pyenv/versions/3.10.1/lib/python3.10/site-packages/apischema/graphql/schema.py", line 975, in graphql_schema
    sub_types = subscriber.types()
  File "/home/ludwig/.pyenv/versions/3.10.1/lib/python3.10/site-packages/apischema/serialization/serialized_methods.py", line 62, in types
    types = get_type_hints(self.func, include_extras=True)
  File "/home/ludwig/.pyenv/versions/3.10.1/lib/python3.10/typing.py", line 1846, in get_type_hints
    value = _eval_type(value, globalns, localns)
  File "/home/ludwig/.pyenv/versions/3.10.1/lib/python3.10/typing.py", line 326, in _eval_type
    return t._evaluate(globalns, localns, recursive_guard)
  File "/home/ludwig/.pyenv/versions/3.10.1/lib/python3.10/typing.py", line 696, in _evaluate
    self.__forward_value__ = _eval_type(
  File "/home/ludwig/.pyenv/versions/3.10.1/lib/python3.10/typing.py", line 326, in _eval_type
    return t._evaluate(globalns, localns, recursive_guard)
  File "/home/ludwig/.pyenv/versions/3.10.1/lib/python3.10/typing.py", line 691, in _evaluate
    eval(self.__forward_code__, globalns, localns),
  File "<string>", line 1, in <module>
NameError: name 'BaseAsset' is not defined
```