### PR TITLE
Deserialization should be done after coercion

### DIFF
--- a/apischema/deserialization/__init__.py
+++ b/apischema/deserialization/__init__.py
@@ -647,7 +647,11 @@ class DeserializationMethodVisitor(
                     if fact.cls is not NoneType
                 )
                 return OptionalMethod(value_method, self.coercer)
-            elif len(method_by_cls) == len(alt_factories):
+            elif len(method_by_cls) == len(alt_factories) and not any(
+                isinstance(x, CoercerMethod) for x in alt_methods
+            ):
+                # Coercion induces a different type in data than type to deserialize.
+                # Prefer UnionMethod in this case.
                 return UnionByTypeMethod(method_by_cls)
             else:
                 return UnionMethod(alt_methods)

--- a/tests/integration/test_object_fields_overriding.py
+++ b/tests/integration/test_object_fields_overriding.py
@@ -15,7 +15,8 @@ class Foo:
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="dataclasses.replace bug with InitVar"
+    (sys.version_info < (3, 8) or ((3, 9) < sys.version_info < (3, 9, 5))),
+    reason="dataclasses.replace bug with InitVar",
 )
 def test_object_fields_overriding():
     set_object_fields(Foo, [])


### PR DESCRIPTION
There was a bug when using a coerce function (such as a JSON converter) on a attribute with a Union and only two types (one of those being not str). UnionByTypeMethod was being called and this one doesn't handle CoercerMethod well.
