### PR TITLE
Fix UncheckedTuples not failing for wrong amount of arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [-C]

--- a/apischema/serialization/methods.py
+++ b/apischema/serialization/methods.py
@@ -315,7 +315,9 @@ class TupleMethod(SerializationMethod):
         elts: list = [None] * len(self.elt_methods)
 
         if len(obj) != len(self.elt_methods):
-            raise ValueError("Inconsistent number of elements in tuple and specified element methods")
+            raise ValueError(
+                "Inconsistent number of elements in tuple and specified element methods"
+            )
 
         for i in range(len(self.elt_methods)):
             method: SerializationMethod = self.elt_methods[i]

--- a/apischema/serialization/methods.py
+++ b/apischema/serialization/methods.py
@@ -313,6 +313,10 @@ class TupleMethod(SerializationMethod):
 
     def serialize(self, obj: tuple, path: Union[int, str, None] = None) -> Any:
         elts: list = [None] * len(self.elt_methods)
+
+        if len(obj) != len(self.elt_methods):
+            raise ValueError("Inconsistent number of elements in tuple and specified element methods")
+
         for i in range(len(self.elt_methods)):
             method: SerializationMethod = self.elt_methods[i]
             elts[i] = method.serialize(obj[i], i)

--- a/examples/ordering.py
+++ b/examples/ordering.py
@@ -31,12 +31,12 @@ class User:
 
 
 user = User("Harry", "Potter", "London", date(1980, 7, 31))
-dump = """{
+dump = f"""{{
     "trigram": "hpr",
     "firstname": "Harry",
     "lastname": "Potter",
-    "age": 41,
+    "age": {user.age},
     "birthdate": "1980-07-31",
     "address": "London"
-}"""
+}}"""
 assert json.dumps(serialize(User, user), indent=4) == dump

--- a/tests/integration/test_serialization_conflicting_union.py
+++ b/tests/integration/test_serialization_conflicting_union.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union, Tuple
+from typing import Tuple, Union
 
 import apischema
 

--- a/tests/integration/test_serialization_conflicting_union.py
+++ b/tests/integration/test_serialization_conflicting_union.py
@@ -10,9 +10,7 @@ class SomeTupleClass:
 
 
 def test_correct_serialization() -> None:
-    serialized_dict = {
-        "bar": [0, 0, 0]
-    }
+    serialized_dict = {"bar": [0, 0, 0]}
 
     as_python_object = apischema.deserialize(type=SomeTupleClass, data=serialized_dict)
 

--- a/tests/integration/test_serialization_conflicting_union.py
+++ b/tests/integration/test_serialization_conflicting_union.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Union, Tuple
+
+import apischema
+
+
+@dataclass(frozen=True)
+class SomeTupleClass:
+    bar: Union[Tuple[int, int], Tuple[int, int, int]]
+
+
+def test_correct_serialization() -> None:
+    serialized_dict = {
+        "bar": [0, 0, 0]
+    }
+
+    as_python_object = apischema.deserialize(type=SomeTupleClass, data=serialized_dict)
+
+    assert as_python_object == SomeTupleClass(bar=(0, 0, 0))
+
+    assert apischema.serialize(as_python_object) == serialized_dict

--- a/tests/unit/serialization/test_methods.py
+++ b/tests/unit/serialization/test_methods.py
@@ -1,0 +1,10 @@
+import pytest
+
+from apischema.serialization import TupleMethod, IntMethod
+
+
+def test_tuple_conversion() -> None:
+    method = TupleMethod(elt_methods=(IntMethod(), IntMethod(), IntMethod()))
+
+    with pytest.raises(ValueError):
+        method.serialize((0, 0, 0, 0))

--- a/tests/unit/serialization/test_methods.py
+++ b/tests/unit/serialization/test_methods.py
@@ -1,6 +1,6 @@
 import pytest
 
-from apischema.serialization import TupleMethod, IntMethod
+from apischema.serialization import IntMethod, TupleMethod
 
 
 def test_tuple_conversion() -> None:


### PR DESCRIPTION
Currently apischema fails to correctly serialize a correctly typed dataclass with a "conflicting" union.

E.g.

```python
from dataclasses import dataclass
from typing import Union, Tuple

import apischema


@dataclass(frozen=True)
class SomeTupleClass:
    bar: Union[Tuple[int, int], Tuple[int, int, int]]


def test_correct_serialization() -> None:
    serialized_dict = {
        "bar": [0, 0, 0]
    }

    as_python_object = apischema.deserialize(type=SomeTupleClass, data=serialized_dict)

    assert as_python_object == SomeTupleClass(bar=(0, 0, 0))

    assert apischema.serialize(as_python_object) == serialized_dict
```

currently fails as the serialization doesn't fail on trying to serialize into the first tuple.

It can be fixed by setting `check_type=True`, but I am not sure if this is really a "type" check or just the union serialization behaving wrongly. 

For now we worked around it with check_type, but as your documentation says  https://wyfo.github.io/apischema/0.18/de_serialization/#type-checking this has futher performance impacts, I would like to discuss if the tuple method shouldn't also be able to handle this conflicting union, as the typing in the dataclass itself seems correct