### PR TITLE
CI: remove Python 3.6 testing and add/fix Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.9']
         include:
-          - python-version: '3.6'
-            pytest-args: --ignore=tests/__generated__/test_recursive_postponned.py
           - python-version: '3.10'
             pytest-args: --cov=apischema --cov-branch --cov-report=xml --cov-report=html
     steps:

--- a/apischema/json_schema/types.py
+++ b/apischema/json_schema/types.py
@@ -34,6 +34,9 @@ class JsonType(str, Enum):
     def from_type(cls: Type) -> "JsonType":
         return TYPE_TO_JSON_TYPE[cls]
 
+    def __str__(self) -> str:
+        return self.value
+
 
 class JsonTypes(Dict[type, JsonType]):
     def __missing__(self, key):

--- a/apischema/typing.py
+++ b/apischema/typing.py
@@ -94,7 +94,9 @@ else:  # pragma: no cover
     except ImportError:
         pass
 
-if sys.version_info >= (3, 7):
+if sys.version_info >= (3, 11):
+    from typing import _collect_parameters as _collect_type_vars
+elif sys.version_info >= (3, 7):
     from typing import _collect_type_vars  # type: ignore
 else:
     from typing import _type_vars as _collect_type_vars

--- a/apischema/typing.py
+++ b/apischema/typing.py
@@ -276,7 +276,7 @@ else:
 
 def is_type(tp: Any) -> bool:
     """isinstance is not enough because in py39: isinstance(list[int], type) == True"""
-    return isinstance(tp, type) and not get_args(tp)
+    return isinstance(tp, type) and not get_args(tp) and tp is not Any
 
 
 def is_union(tp: Any) -> bool:

--- a/examples/flattened.py
+++ b/examples/flattened.py
@@ -20,7 +20,7 @@ class RootJsonSchema:
     schema: str | UndefinedType = field(default=Undefined, metadata=alias("$schema"))
     defs: list[JsonSchema] = field(default_factory=list, metadata=alias("$defs"))
     # This field schema is flattened inside the owning one
-    json_schema: JsonSchema = field(default=JsonSchema(), metadata=flatten)
+    json_schema: JsonSchema = field(default_factory=JsonSchema, metadata=flatten)
 
 
 data = {

--- a/examples/ordering.py
+++ b/examples/ordering.py
@@ -31,12 +31,12 @@ class User:
 
 
 user = User("Harry", "Potter", "London", date(1980, 7, 31))
-dump = """{
+dump = f"""{{
     "trigram": "hpr",
     "firstname": "Harry",
     "lastname": "Potter",
-    "age": 41,
+    "age": {user.age},
     "birthdate": "1980-07-31",
     "address": "London"
-}"""
+}}"""
 assert json.dumps(serialize(User, user), indent=4) == dump

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,9 @@ ignore = E203, E302, E501, W503, E731, E741
 [isort]
 profile = black
 
+[tool:pytest]
+asyncio_mode = auto
+
 [coverage:report]
 ;fail_under = 100
 precision = 2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,7 +5,6 @@ bson==0.5.10
 docstring-parser==0.13
 pydantic==1.9.0
 pytest==7.0.1
-pytest-aiohttp==1.0.4
 pytest-cov==3.0.0
 pytest-asyncio==0.17.2
 SQLAlchemy==1.4.32

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,8 +5,9 @@ bson==0.5.10
 docstring-parser==0.13
 pydantic==1.9.0
 pytest==7.0.1
+pytest-aiohttp==1.0.4
 pytest-cov==3.0.0
-pytest-asyncio==0.16.0
+pytest-asyncio==0.17.2
 SQLAlchemy==1.4.32
 typing-extensions==4.0.1
 Cython==0.29.27


### PR DESCRIPTION
* Python 3.6 is unavailable for Ubuntu 22.04. 
    * Closes #514 by way of removing the job and focusing on newer versions.
* Fixed a general test bug that assumed Harry Potter would be 41 forever
* Adds in a CI job for Python 3.11
* Fixes Python 3.11 support, at least to the point of a passing test suite:
   * Bumps pytest-asyncio version in test suite and sets "auto" mode to avoid pytest-asyncio's deprecation warning
   * Fixes string enum representation, primarily for the test suite (0df3dcf), otherwise the expected error messages change (`[{'err': 'expected type JsonType.INTEGER, found JsonType.NULL', 'loc': ['bar']}]` instead of `[{'err': 'expected type integer, found null', 'loc': ['bar']}]`)
   * Follows change from the standard library `typing._collect_type_vars` -> `_collect_parameters` (closes #485)
   * Fixes a failing example due to a new check for mutable default values in frozen dataclass fields
   * In Python 3.11, `typing.Any` is now a type subclass (related to https://github.com/python/cpython/issues/91154). This broke serialization of JSON schemas in an unexpected (to me) way, resulting in `test_schema_versions.py` failing to use the correct converter for `OPEN_API_3_0`