### PR TITLE
feat: update benchmarks to use pydantic v2

### DIFF
--- a/benchmark/benchmarks/pydantic.py
+++ b/benchmark/benchmarks/pydantic.py
@@ -42,11 +42,11 @@ class Receipt(CamelModel):
 def methods(model: Type[CamelModel]) -> Methods:
     def serialize_receipts(obj: Receipt):
         obj.date.isoformat()
-        return obj.dict()
+        return obj.model_dump()
 
     return Methods(
         lambda data: model(**data),
-        model.dict if model is Message else serialize_receipts,
+        model.model_dump if model is Message else serialize_receipts,
     )
 
 

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -3,6 +3,6 @@ marshmallow==3.19.0
 mashumaro==3.2
 matplotlib==3.6.2
 pandas==1.5.2
-pydantic==1.10.2
+pydantic==2.4.2
 typedload==2.20
 pyserde==0.9.6


### PR DESCRIPTION
resolves #573 

on my mac m1 pro:
```
❯ python benchmark/main.py
====================
cattr
        simple
                first run: 0.0007056250000000001
                deserialization: 1.1770882095224807e-06
                serialization: 7.863142280111788e-07
        complex
                first run: 0.0018778750000000002
                deserialization: 4.091458749971935e-06
                serialization: 1.554307502519805e-06
startup time: 0.006251917
====================
serde
        simple
                first run: 1.7500000000000002e-05
                deserialization: 1.423428540038003e-06
                serialization: 7.311406669905409e-07
        complex
                first run: 7.479100000000001e-05
                deserialization: 3.7131691649847197e-06
                serialization: 2.5033245849772355e-06
startup time: 0.08227091600000001
====================
marshmallow
        simple
                first run: 9.1792e-05
                deserialization: 8.994797500054119e-06
                serialization: 3.5153300000092712e-06
        complex
                first run: 0.00058675
                deserialization: 4.4004447849874855e-05
                serialization: 1.4529686474998017e-05
startup time: 0.0023029170000000002
====================
pydantic
        simple
                first run: 0.000196125
                deserialization: 8.689104579971172e-07
                serialization: 7.327865839906736e-07
        complex
                first run: 0.001872916
                deserialization: 2.9916893749759762e-06
                serialization: 2.9404354150756266e-06
startup time: 0.031410124
====================
mashumaro
        simple
                first run: 1e-05
                deserialization: 8.415731670102104e-07
                serialization: 2.684800005008583e-07
        complex
                first run: 6.4875e-05
                deserialization: 3.590112495076028e-06
                serialization: 1.2949807299810346e-06
startup time: 0.005440708
====================
apischema
        simple
                first run: 0.0009481250000000001
                deserialization: 3.687402920040768e-07
                serialization: 1.521124270002474e-07
        complex
                first run: 0.00254375
                deserialization: 2.41705437998462e-06
                serialization: 8.352246249996824e-07
startup time: 0.012697457999999998
====================
typedload
        simple
                first run: 9.383400000000001e-05
                deserialization: 4.790121459955117e-06
                serialization: 9.729756870146958e-06
        complex
                first run: 0.00038783400000000004
                deserialization: 1.795490520016756e-05
                serialization: 5.020940429822076e-05
startup time: 0.006129793000000001
```