### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: scripts/cythonize.sh
       - run: scripts/generate_tests_from_examples.py
-      - uses: pypa/cibuildwheel@v2.11.3
+      - uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_SKIP: pp*
           CIBW_TEST_COMMAND: pytest {project}/tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9']
         include:
           - python-version: '3.11'
             pytest-args: --cov=apischema --cov-branch --cov-report=xml --cov-report=html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: pycln
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black

--- a/scripts/requirements.cython.txt
+++ b/scripts/requirements.cython.txt
@@ -1,1 +1,2 @@
-Cython==0.29.32
+Cython==3.0.3
+setuptools>=68.2; python_version>="3.12"

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     cmdclass={"build_ext": custom_build_ext},

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,8 +3,8 @@ attrs==22.1.0
 bson==0.5.10
 docstring-parser==0.15
 pydantic==1.10.2
-pytest==7.2.0
+pytest==7.4.2
 pytest-cov==4.0.0
 pytest-asyncio==0.20.3
 SQLAlchemy==1.4.45
-typing-extensions==4.4.0
+typing-extensions==4.8.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,4 +7,5 @@ pytest==7.4.2
 pytest-cov==4.0.0
 pytest-asyncio==0.20.3
 SQLAlchemy==1.4.45
-typing-extensions==4.8.0
+typing-extensions==4.8.0;python_version>="3.8"
+typing-extensions==4.7.1;python_version<"3.8"


### PR DESCRIPTION
- Update cython version for compatibility with Python 3.12
- Update cibuildwheel to build 3.12 by default
- Add `3.12` to ci test matrix
- Add classifier for 3.12
- Add setuptools as cythonize requirement. `distutils` isn't shipped with Python anymore.
- Update pytest to fix DeprecationWarnings
- Update typing_extensions to fix a Python 3.12 test error